### PR TITLE
Fix init to render animated badge + bump 0.2.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cc-proficiency",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cc-proficiency",
-      "version": "0.2.6",
+      "version": "0.2.7",
       "license": "Apache-2.0",
       "bin": {
         "cc-proficiency": "dist/cli/index.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-proficiency",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "Claude Code proficiency badge generator — analyze usage patterns across 5 domains aligned with Claude Certified Architect",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -1,5 +1,6 @@
 import { renderBadge } from "../../renderer/svg.js";
-import { loadStore, loadConfig, saveConfig, saveBadge, getBadgePath, getStoreDir, computeTokenWindows } from "../../store/local-store.js";
+import { renderAnimatedBadge } from "../../renderer/animated-svg.js";
+import { loadStore, loadConfig, saveConfig, saveBadge, saveAnimatedBadge, getBadgePath, getStoreDir, computeTokenWindows } from "../../store/local-store.js";
 import { ensureStoreDir } from "../../store/queue.js";
 import { isGhAuthenticated, getGhUsername, createGist, updateGist, getGistRawUrl } from "../../gist/uploader.js";
 import { detectLocale } from "../../i18n/locales.js";
@@ -40,9 +41,14 @@ export async function cmdInit(): Promise<void> {
 
   const store = loadStore();
   let badgeSvg = '<svg xmlns="http://www.w3.org/2000/svg"><text>No data</text></svg>';
+  let animatedSvg = badgeSvg;
   if (store.lastResult) {
-    badgeSvg = renderBadge(store.lastResult, getConfigLocale(), computeTokenWindows(store.tokenLog));
+    const tokenWindows = computeTokenWindows(store.tokenLog);
+    const locale = getConfigLocale();
+    badgeSvg = renderBadge(store.lastResult, locale, tokenWindows);
+    animatedSvg = renderAnimatedBadge(store.lastResult, locale, tokenWindows);
     saveBadge(badgeSvg);
+    saveAnimatedBadge(animatedSvg);
   }
 
   if (config.username && isGhAuthenticated() && !config.gistId) {
@@ -59,6 +65,7 @@ export async function cmdInit(): Promise<void> {
     }
   } else if (config.gistId && isGhAuthenticated()) {
     const gistResult = updateGist(config.gistId, badgeSvg);
+    updateGist(config.gistId, animatedSvg, "cc-proficiency-animated.svg");
     if (gistResult.success) {
       const rawUrl = getGistRawUrl(config.username ?? "", config.gistId);
       console.log(`  \u2713 Badge pushed to Gist: ${rawUrl}`);

--- a/tests/cli/self-update.test.ts
+++ b/tests/cli/self-update.test.ts
@@ -21,25 +21,25 @@ beforeEach(() => {
 
 describe("checkForUpdate", () => {
   it("returns available: false when current >= latest", async () => {
-    vi.mocked(fetchLatestVersion).mockResolvedValue("0.2.6");
+    vi.mocked(fetchLatestVersion).mockResolvedValue("0.2.7");
     vi.mocked(compareVersions).mockReturnValue(0);
-    const result = await checkForUpdate("0.2.6");
+    const result = await checkForUpdate("0.2.7");
     expect(result.available).toBe(false);
-    expect(result.current).toBe("0.2.6");
+    expect(result.current).toBe("0.2.7");
   });
 
   it("returns available: true when outdated", async () => {
     vi.mocked(fetchLatestVersion).mockResolvedValue("0.3.0");
     vi.mocked(compareVersions).mockReturnValue(1);
-    const result = await checkForUpdate("0.2.6");
+    const result = await checkForUpdate("0.2.7");
     expect(result.available).toBe(true);
-    expect(result.current).toBe("0.2.6");
+    expect(result.current).toBe("0.2.7");
     expect(result.latest).toBe("0.3.0");
   });
 
   it("returns fetchFailed: true when registry unreachable", async () => {
     vi.mocked(fetchLatestVersion).mockResolvedValue(null);
-    const result = await checkForUpdate("0.2.6");
+    const result = await checkForUpdate("0.2.7");
     expect(result.available).toBe(false);
     expect(result.fetchFailed).toBe(true);
   });


### PR DESCRIPTION
## Summary
- Fix `cmdInit` to render and push both static and animated SVG badges (was only creating static)
- Bump version to 0.2.7

## Test plan
- [x] 267 tests pass
- [x] Build clean